### PR TITLE
Add `@noescape` attributes.

### DIFF
--- a/Sources/MulticastDelegate.swift
+++ b/Sources/MulticastDelegate.swift
@@ -71,7 +71,7 @@ public class MulticastDelegate<T> {
      *
      *  - parameter invocation: The closure to be invoked on each delegate.
      */
-	public func invokeDelegates(invocation: (T) -> ()) {
+	public func invokeDelegates(@noescape invocation: (T) -> ()) {
 		
 		for delegate in delegates.allObjects {
 			invocation(delegate as! T)
@@ -134,7 +134,7 @@ public func -=<T>(left: MulticastDelegate<T>, right: T) -> MulticastDelegate<T> 
  *  - returns: The `MulticastDelegate` after all its delegates have been invoked
  */
 infix operator |> { associativity left precedence 130 }
-public func |><T>(left: MulticastDelegate<T>, right: (T) -> ()) -> MulticastDelegate<T> {
+public func |><T>(left: MulticastDelegate<T>, @noescape right: (T) -> ()) -> MulticastDelegate<T> {
 	
 	left.invokeDelegates(right)
 	return left


### PR DESCRIPTION
Add `@noescape` attributes to decorate the closures.

This has two nice benefits:
(1) Eliminates need for `self` inside the closure.
(2) Small compiler optimizations

Even if a call is made _inside_ the closure that isn't `@noesacpe`, this is okay: it only matters about the _closure_ itself.

For more details, see here:

http://nshint.io/blog/2015/10/23/noescape-attribute/
