### PR TITLE
MulticastDelegate.delegates property changed to 'let'

### DIFF
--- a/Sources/MulticastDelegate.swift
+++ b/Sources/MulticastDelegate.swift
@@ -14,7 +14,7 @@ import Foundation
 public class MulticastDelegate<T> {
 	
     /// The delegates hash table.
-    private var delegates: NSHashTable
+    private let delegates: NSHashTable
     
     /**
      *  Use this method to initialize a new `MulticastDelegate` specifying whether delegate references should be weak or


### PR DESCRIPTION
`NSHashTable` is a reference type so it should be a constant.
