### PR TITLE
Add/remove delegate operators no longer return values

### DIFF
--- a/Sources/MulticastDelegate.swift
+++ b/Sources/MulticastDelegate.swift
@@ -98,13 +98,10 @@ public class MulticastDelegate<T> {
  *
  *  - parameter left:   The multicast delegate
  *  - parameter right:  The delegate to be added
- *
- *  - returns: The `MulticastDelegate` instance with the `right` delegate parameter added
  */
-public func +=<T>(left: MulticastDelegate<T>, right: T) -> MulticastDelegate<T> {
+public func +=<T>(left: MulticastDelegate<T>, right: T) {
 	
 	left.addDelegate(right)
-	return left
 }
 
 /**
@@ -114,13 +111,10 @@ public func +=<T>(left: MulticastDelegate<T>, right: T) -> MulticastDelegate<T> 
  *
  *  - parameter left:   The multicast delegate
  *  - parameter right:  The delegate to be removed
- *
- *  - returns: The `MulticastDelegate` instance with the `right` delegate parameter removed
  */
-public func -=<T>(left: MulticastDelegate<T>, right: T) -> MulticastDelegate<T> {
+public func -=<T>(left: MulticastDelegate<T>, right: T) {
 	
 	left.removeDelegate(right)
-	return left
 }
 
 /**


### PR DESCRIPTION
`+=` and `-=` used to return `MulticastDelegate`.
By convention these operators mutate `lhs` and not return anything.

This came up in **Swift 3** where the compiler gave me warnings about unused results, because the convention for default warning has changed.

Still, event if **Swift 2** doesn't warn, I think this approach follows conventions better and is also prepared better for **Swfit 3**.

`CollectionType` example:

``` swift
/// Extend `lhs` with the elements of `rhs`.
public func +=<Element, C : CollectionType where C.Generator.Element == Element>(inout lhs: [Element], rhs: C)
```

`Int32` example

``` swift
public func -=(inout lhs: Int32, rhs: Int32)
```
