### PR TITLE
Revert "Fixed invokeDelegates operator to use the correct return"

### DIFF
--- a/Sources/MulticastDelegate.swift
+++ b/Sources/MulticastDelegate.swift
@@ -128,7 +128,8 @@ public func -=<T>(left: MulticastDelegate<T>, right: T) {
  *  - returns: The `MulticastDelegate` after all its delegates have been invoked
  */
 infix operator |> { associativity left precedence 130 }
-public func |><T>(left: MulticastDelegate<T>, @noescape right: (T) -> ()) {
+public func |><T>(left: MulticastDelegate<T>, @noescape right: (T) -> ()) -> MulticastDelegate<T> {
 	
 	left.invokeDelegates(right)
+	return left
 }


### PR DESCRIPTION
This reverts commit eaa4e54e5daaaed316ddabec5364d557626aef8d.

Per discussion on #8, chaining is a reasonable use-case that should be allowed.
