### PR TITLE
updated podspec to avoid errors when trying to use cocoapods from an iOS only project

### DIFF
--- a/MulticastDelegateSwift.podspec
+++ b/MulticastDelegateSwift.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name     = 'MulticastDelegateSwift'
   s.version  = '2.1.0'
-  s.platform = :ios, '8.0'
-  s.platform = :osx, '10.10'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
   s.license  = { :type => 'MIT'}
   s.summary  = 'Swift Multicast Delegate'
   s.homepage = 'https://github.com/jonasman/MulticastDelegate'


### PR DESCRIPTION
updated podspec to use ios.deployment_target and oxs.deployment_target to avoid errors when trying to use cocoapods from an iOS only project

Problem: 
Cannot run `pod install` on the latest version of `MulticastDelegate` (2.1.0). Cocoapods shows an error message that it does not support the platform 'ios'. My company had to downgrade to `MulticastDelegate` 2.0.1 to allow pod install to be able to run
![screen shot 2018-02-26 at 4 03 24 pm](https://user-images.githubusercontent.com/15187490/36654332-019cc460-1b10-11e8-8fc0-7547d8749f96.png)

I believe this problem is due to this commit here: https://github.com/jonasman/MulticastDelegate/commit/d3fe045be7a190e5d509db37d0c9b534d85cbdb0

This PR is updating the podspec to match the format specified in this cocoapod issue:
https://github.com/CocoaPods/CocoaPods/issues/4185

Here is an example from Alamofire that my change is based on:
https://github.com/Alamofire/Alamofire/blob/master/Alamofire.podspec